### PR TITLE
Migrate scripts into subdirectory

### DIFF
--- a/scripts/SatEvo.py
+++ b/scripts/SatEvo.py
@@ -8,12 +8,12 @@
 
 ######################## set up the environment #########################
 
-from . import config as cfg
-import evolve as ev
-from .profiles import Dekel, MN
-from orbit import orbit
-import galhalo as gh
-import aux
+from SatGen import config as cfg
+from SatGen import evolve as ev
+from SatGen.profiles import Dekel, MN
+from SatGen.orbit import orbit
+from SatGen import galhalo as gh
+from SatGen import aux
 
 import numpy as np
 import os

--- a/scripts/SubEvo.py
+++ b/scripts/SubEvo.py
@@ -14,12 +14,12 @@
 
 ######################## set up the environment #########################
 
-from . import config as cfg
-from . import cosmo as co
-from . import evolve as ev
-from .profiles import NFW, Green
-from .orbit import orbit
-from . import aux
+from SatGen import config as cfg
+from SatGen import cosmo as co
+from SatGen import evolve as ev
+from SatGen.profiles import NFW, Green
+from SatGen.orbit import orbit
+from SatGen import aux
 
 import numpy as np
 import sys

--- a/scripts/TreeGen.py
+++ b/scripts/TreeGen.py
@@ -1,74 +1,68 @@
-################################ TreeGen_Sub ################################
+################################ TreeGen ################################
 
 # Generate halo merger trees using the Parkinson et al. (2008) algorithm.
-# Slightly modified from original TreeGen to only produce quantities necessary
-# for dark matter subhalo evolution. Additionally, this version introduces
-# Zhao-Zhou Li's infall orbital parameter distribution.
 
 # Arthur Fangzhou Jiang 2015 Yale University
 # Arthur Fangzhou Jiang 2016 Hebrew University
 # Arthur Fangzhou Jiang 2019 Hebrew University
-# Sheridan Beckwith Green 2020 Yale University
 
 ######################## set up the environment #########################
 
 # ---user modules
-from . import config as cfg
-from . import cosmo as co
-from . import init
-from .profiles import NFW
-from . import aux
+from SatGen import config as cfg
+from SatGen import cosmo as co
+from SatGen import init
+from SatGen.profiles import Dekel
+from SatGen import aux
 
 # ---python modules
 import numpy as np
 import time
-from multiprocessing import Pool
-import sys
-from os import path
+from multiprocessing import Pool, cpu_count
+
+# <<< for clean on-screen prints, use with caution, make sure that
+# the warning is not prevalent or essential for the result
+import warnings
+
+warnings.filterwarnings("ignore", category=RuntimeWarning)
 
 ############################# user control ##############################
 
-# ---target halo and desired resolution
-lgM0 = 14.2 - np.log10(cfg.h)  # log10(Msun), corresponds to 10^14.2 Msun/h
-cfg.psi_res = 10 ** -5.0
+# ---target halo, desired resolution, number of trees
+lgM0_lo = 14.00
+lgM0_hi = 14.50
 z0 = 0.0
-lgMres = lgM0 + np.log10(cfg.psi_res)  # psi_{res} = 10^-5 by default
-Ntree = 2000
+lgMres = 8.5
+Ntree = 24
 
-# ---orbital parameter sampler preference
-optype = "zzli"  # 'zzli' or 'zentner' or 'jiang'
+# ---baryonic-effect choice and output control
+HaloResponse = "NIHAO"
+outfile1 = "./OUTPUT_TREE_CLUSTER_NIHAO/tree%i_lgM%.2f.npz"  #%(itree,lgM0)
 
-# ---concentration model preference
-conctype = "zhao"  # 'zhao' or 'vdb'
-
-# ---for output
-outfile1 = "./OUTPUT_TREE/tree%i_lgM%.2f.npz"  #%(itree,lgM0)
+# HaloResponse = 'APOSTLE'
+# outfile1 = './OUTPUT_TREE_CLUSTER_APOSTLE/tree%i_lgM%.2f.npz'#%(itree,lgM0)
 
 ############################### compute #################################
 
 print(
-    ">>> Generating %i trees for log(M_0)=%.2f at log(M_res)=%.2f..."
-    % (Ntree, lgM0, lgMres)
+    ">>> Generating %i trees for log(M_0)=%.2f-%.2f at log(M_res)=%.2f..."
+    % (Ntree, lgM0_lo, lgM0_hi, lgMres)
 )
 
 # ---
 time_start = time.time()
 
 
-def loop(itree):  # for itree in range(Ntree):
-
+# for itree in range(Ntree):
+def loop(itree):
     """
     Replaces the loop "for itree in range(Ntree):", for parallelization.
     """
-
-    # check if this one has already been ran
-    if path.exists(outfile1 % (itree, lgM0)):
-        return
-
     time_start_tmp = time.time()
 
     np.random.seed()  # [important!] reseed the random number generator
 
+    lgM0 = lgM0_lo + np.random.random() * (lgM0_hi - lgM0_lo)
     cfg.M0 = 10.0 ** lgM0
     cfg.z0 = z0
     cfg.Mres = 10.0 ** lgMres
@@ -95,6 +89,11 @@ def loop(itree):  # for itree in range(Ntree):
 
     VirialRadius = np.zeros((cfg.Nmax, cfg.Nz), np.float32) - 99.0
     concentration = np.zeros((cfg.Nmax, cfg.Nz), np.float32) - 99.0
+    DekelConcentration = np.zeros((cfg.Nmax, cfg.Nz), np.float32) - 99.0
+    DekelSlope = np.zeros((cfg.Nmax, cfg.Nz), np.float32) - 99.0
+
+    StellarMass = np.zeros((cfg.Nmax, cfg.Nz)) - 99.0
+    StellarSize = np.zeros((cfg.Nmax, cfg.Nz), np.float32) - 99.0
 
     coordinates = np.zeros((cfg.Nmax, cfg.Nz, 6), np.float32)
 
@@ -149,32 +148,53 @@ def loop(itree):  # for itree in range(Ntree):
         # coarser output timesteps, cfg.zsample
         Msample, zsample = aux.downsample(M, z, cfg.zsample)
         iz = aux.FindClosestIndices(cfg.zsample, zsample)
-        if isinstance(iz, np.int64):
-            iz = np.array([iz])  # avoids error in loop below
-            zsample = np.array([zsample])
-            Msample = np.array([Msample])
         izleaf = aux.FindNearestIndex(cfg.zsample, zleaf)
-        # Note: zsample[j] is same as cfg.zsample[iz[j]]
 
         # compute halo structure throughout time on the coarse grid, up
         # to the leaf point
         t = co.t(z, cfg.h, cfg.Om, cfg.OL)
-        c2, Rv = [], []
+        c, a, c2, Rv = [], [], [], []
         for i in iz:
             if i > (izleaf + 1):
                 break  # only compute structure below leaf
             msk = z >= cfg.zsample[i]
             if True not in msk:
                 break  # safety
-            c2i = init.c2_fromMAH(M[msk], t[msk], conctype)
-            Rvi = init.Rvir(M[msk][0], Delta=cfg.Dvsample[i], z=cfg.zsample[i])
+            ci, ai, Msi, c2i, c2DMOi = init.Dekel_fromMAH(
+                M[msk], t[msk], cfg.zsample[i], HaloResponse=HaloResponse
+            )
+            Rvi = init.Rvir(M[msk][0], Delta=200.0, z=cfg.zsample[i])
+            c.append(ci)
+            a.append(ai)
             c2.append(c2i)
             Rv.append(Rvi)
+            if i == iz[0]:
+                Ms = Msi
             # print('    i=%6i,ci=%8.2f,ai=%8.2f,log(Msi)=%8.2f,c2i=%8.2f'%\
             #    (i,ci,ai,np.log10(Msi),c2i)) # <<< for test
+        if len(c) == 0:  # <<< safety, dealing with rare cases where the
+            # branch's root z[0] is close to the maximum redshift -- when
+            # this happens, the mass history has only one element, and
+            # z[0] can be slightly above cfg.zsample[i] for the very
+            # first iteration, leaving the lists c,a,c2,Rv never updated
+            ci, ai, Msi, c2i = init.Dekel_fromMAH(M, t, z[0], HaloResponse=HaloResponse)
+            c.append(ci)
+            a.append(ai)
+            c2.append(c2i)
+            Rv.append(Rvi)
+            Ms = Msi
+            # <<< test
+            # print('    branch root near max redshift: z=%7.2f,log(M)=%7.2f,c=%7.2f,a=%7.2f,c2=%7.2f,log(Ms)=%7.2f'%\
+            #    (z[0],np.log10(M[0]),c[0],a[0],c2[0],np.log10(Ms)))
+        c = np.array(c)
+        a = np.array(a)
         c2 = np.array(c2)
         Rv = np.array(Rv)
         Nc = len(c2)  # length of a branch over which c2 is computed
+
+        # compute stellar size at the root of the branch, i.e., at the
+        # accretion epoch (z[0])
+        Re = init.Reff(Rv[0], c2[0])
 
         # use the redshift id and parent-branch id to access the parent
         # branch's information at our current branch's accretion epoch,
@@ -183,20 +203,14 @@ def loop(itree):  # for itree in range(Ntree):
             xv = np.zeros(6)
         else:
             Mp = mass[ip, iz[0]]
-            c2p = concentration[ip, iz[0]]
-            hp = NFW(Mp, c2p, Delta=cfg.Dvsample[iz[0]], z=zsample[0])
-            if optype == "zentner":
-                eps = 1.0 / np.pi * np.arccos(1.0 - 2.0 * np.random.random())
-                xv = init.orbit(hp, xc=1.0, eps=eps)
-            elif optype == "zzli":
-                vel_ratio, gamma = init.ZZLi2020(hp, Msample[0], zsample[0])
-                xv = init.orbit_from_Li2020(hp, vel_ratio, gamma)
-            elif optype == "jiang":
-                sp = NFW(Msample[0], c2[0], Delta=cfg.Dvsample[iz[0]], z=zsample[0])
-                xv = init.orbit_from_Jiang2015(hp, sp, zsample[0])
+            cp = DekelConcentration[ip, iz[0]]
+            ap = DekelSlope[ip, iz[0]]
+            hp = Dekel(Mp, cp, ap, Delta=200.0, z=zsample[0])
+            eps = 1.0 / np.pi * np.arccos(1.0 - 2.0 * np.random.random())
+            xv = init.orbit(hp, xc=1.0, eps=eps)
 
         # <<< test
-        # print('    id=%6i,k=%2i,z[0]=%7.2f,log(M[0])=%7.2f,c=%7.2f,a=%7.2f,c2=%7.2f,log(Ms)=%7.2f,Re=%7.2f,xv=%7.2f,%7.2f,%7.2f,%7.2f,%7.2f,%7.2f'%\
+        # print('    id=%6i,k=%2i,z=%7.2f,log(M)=%7.2f,c=%7.2f,a=%7.2f,c2=%7.2f,log(Ms)=%7.2f,Re=%7.2f,xv=%7.2f,%7.2f,%7.2f,%7.2f,%7.2f,%7.2f'%\
         #    (id,k,z[0],np.log10(M[0]),c[0],a[0],c2[0],np.log10(Ms),Re, xv[0],xv[1],xv[2],xv[3],xv[4],xv[5]))
 
         # update the arrays for output
@@ -206,6 +220,11 @@ def loop(itree):  # for itree in range(Ntree):
 
         VirialRadius[id, iz[0] : iz[0] + Nc] = Rv
         concentration[id, iz[0] : iz[0] + Nc] = c2
+        DekelConcentration[id, iz[0] : iz[0] + Nc] = c
+        DekelSlope[id, iz[0] : iz[0] + Nc] = a
+
+        StellarMass[id, iz[0]] = Ms
+        StellarSize[id, iz[0]] = Re
 
         coordinates[id, iz[0], :] = xv
 
@@ -233,6 +252,10 @@ def loop(itree):  # for itree in range(Ntree):
     ParentID = ParentID[: id + 1, :]
     VirialRadius = VirialRadius[: id + 1, :]
     concentration = concentration[: id + 1, :]
+    DekelConcentration = DekelConcentration[: id + 1, :]
+    DekelSlope = DekelSlope[: id + 1, :]
+    StellarMass = StellarMass[: id + 1, :]
+    StellarSize = StellarSize[: id + 1, :]
     coordinates = coordinates[: id + 1, :, :]
     np.savez(
         outfile1 % (itree, lgM0),
@@ -243,20 +266,25 @@ def loop(itree):  # for itree in range(Ntree):
         ParentID=ParentID,
         VirialRadius=VirialRadius,
         concentration=concentration,
+        DekelConcentration=DekelConcentration,
+        DekelSlope=DekelSlope,
+        # VirialOverdensity = VirialOverdensity, # <<< no need in TreeGen
+        StellarMass=StellarMass,
+        StellarSize=StellarSize,
         coordinates=coordinates,
     )
 
     time_end_tmp = time.time()
     print(
-        "    Tree %5i: %6i branches, %2i order, %8.1f sec"
-        % (itree, Nbranch, k, time_end_tmp - time_start_tmp)
+        "    Tree %5i: log(M_0)=%6.2f, %6i branches, %2i order, %8.1f sec"
+        % (itree, lgM0, Nbranch, k, time_end_tmp - time_start_tmp)
     )
 
 
+# ---for parallelization, comment for testing in serial mode
 if __name__ == "__main__":
-    Ncores = int(sys.argv[1])
-    pool = Pool(Ncores)  # use as many as requested
-    pool.map(loop, range(Ntree), chunksize=1)
+    pool = Pool(cpu_count())  # use all cores
+    pool.map(loop, range(Ntree))
 
 time_end = time.time()
 print("    total time: %5.2f hours" % ((time_end - time_start) / 3600.0))

--- a/scripts/TreeGen_Sub.py
+++ b/scripts/TreeGen_Sub.py
@@ -1,68 +1,74 @@
-################################ TreeGen ################################
+################################ TreeGen_Sub ################################
 
 # Generate halo merger trees using the Parkinson et al. (2008) algorithm.
+# Slightly modified from original TreeGen to only produce quantities necessary
+# for dark matter subhalo evolution. Additionally, this version introduces
+# Zhao-Zhou Li's infall orbital parameter distribution.
 
 # Arthur Fangzhou Jiang 2015 Yale University
 # Arthur Fangzhou Jiang 2016 Hebrew University
 # Arthur Fangzhou Jiang 2019 Hebrew University
+# Sheridan Beckwith Green 2020 Yale University
 
 ######################## set up the environment #########################
 
 # ---user modules
-from . import config as cfg
-from . import cosmo as co
-from . import init
-from .profiles import Dekel
-from . import aux
+from SatGen import config as cfg
+from SatGen import cosmo as co
+from SatGen import init
+from SatGen.profiles import NFW
+from SatGen import aux
 
 # ---python modules
 import numpy as np
 import time
-from multiprocessing import Pool, cpu_count
-
-# <<< for clean on-screen prints, use with caution, make sure that
-# the warning is not prevalent or essential for the result
-import warnings
-
-warnings.filterwarnings("ignore", category=RuntimeWarning)
+from multiprocessing import Pool
+import sys
+from os import path
 
 ############################# user control ##############################
 
-# ---target halo, desired resolution, number of trees
-lgM0_lo = 14.00
-lgM0_hi = 14.50
+# ---target halo and desired resolution
+lgM0 = 14.2 - np.log10(cfg.h)  # log10(Msun), corresponds to 10^14.2 Msun/h
+cfg.psi_res = 10 ** -5.0
 z0 = 0.0
-lgMres = 8.5
-Ntree = 24
+lgMres = lgM0 + np.log10(cfg.psi_res)  # psi_{res} = 10^-5 by default
+Ntree = 2000
 
-# ---baryonic-effect choice and output control
-HaloResponse = "NIHAO"
-outfile1 = "./OUTPUT_TREE_CLUSTER_NIHAO/tree%i_lgM%.2f.npz"  #%(itree,lgM0)
+# ---orbital parameter sampler preference
+optype = "zzli"  # 'zzli' or 'zentner' or 'jiang'
 
-# HaloResponse = 'APOSTLE'
-# outfile1 = './OUTPUT_TREE_CLUSTER_APOSTLE/tree%i_lgM%.2f.npz'#%(itree,lgM0)
+# ---concentration model preference
+conctype = "zhao"  # 'zhao' or 'vdb'
+
+# ---for output
+outfile1 = "./OUTPUT_TREE/tree%i_lgM%.2f.npz"  #%(itree,lgM0)
 
 ############################### compute #################################
 
 print(
-    ">>> Generating %i trees for log(M_0)=%.2f-%.2f at log(M_res)=%.2f..."
-    % (Ntree, lgM0_lo, lgM0_hi, lgMres)
+    ">>> Generating %i trees for log(M_0)=%.2f at log(M_res)=%.2f..."
+    % (Ntree, lgM0, lgMres)
 )
 
 # ---
 time_start = time.time()
 
 
-# for itree in range(Ntree):
-def loop(itree):
+def loop(itree):  # for itree in range(Ntree):
+
     """
     Replaces the loop "for itree in range(Ntree):", for parallelization.
     """
+
+    # check if this one has already been ran
+    if path.exists(outfile1 % (itree, lgM0)):
+        return
+
     time_start_tmp = time.time()
 
     np.random.seed()  # [important!] reseed the random number generator
 
-    lgM0 = lgM0_lo + np.random.random() * (lgM0_hi - lgM0_lo)
     cfg.M0 = 10.0 ** lgM0
     cfg.z0 = z0
     cfg.Mres = 10.0 ** lgMres
@@ -89,11 +95,6 @@ def loop(itree):
 
     VirialRadius = np.zeros((cfg.Nmax, cfg.Nz), np.float32) - 99.0
     concentration = np.zeros((cfg.Nmax, cfg.Nz), np.float32) - 99.0
-    DekelConcentration = np.zeros((cfg.Nmax, cfg.Nz), np.float32) - 99.0
-    DekelSlope = np.zeros((cfg.Nmax, cfg.Nz), np.float32) - 99.0
-
-    StellarMass = np.zeros((cfg.Nmax, cfg.Nz)) - 99.0
-    StellarSize = np.zeros((cfg.Nmax, cfg.Nz), np.float32) - 99.0
 
     coordinates = np.zeros((cfg.Nmax, cfg.Nz, 6), np.float32)
 
@@ -148,53 +149,32 @@ def loop(itree):
         # coarser output timesteps, cfg.zsample
         Msample, zsample = aux.downsample(M, z, cfg.zsample)
         iz = aux.FindClosestIndices(cfg.zsample, zsample)
+        if isinstance(iz, np.int64):
+            iz = np.array([iz])  # avoids error in loop below
+            zsample = np.array([zsample])
+            Msample = np.array([Msample])
         izleaf = aux.FindNearestIndex(cfg.zsample, zleaf)
+        # Note: zsample[j] is same as cfg.zsample[iz[j]]
 
         # compute halo structure throughout time on the coarse grid, up
         # to the leaf point
         t = co.t(z, cfg.h, cfg.Om, cfg.OL)
-        c, a, c2, Rv = [], [], [], []
+        c2, Rv = [], []
         for i in iz:
             if i > (izleaf + 1):
                 break  # only compute structure below leaf
             msk = z >= cfg.zsample[i]
             if True not in msk:
                 break  # safety
-            ci, ai, Msi, c2i, c2DMOi = init.Dekel_fromMAH(
-                M[msk], t[msk], cfg.zsample[i], HaloResponse=HaloResponse
-            )
-            Rvi = init.Rvir(M[msk][0], Delta=200.0, z=cfg.zsample[i])
-            c.append(ci)
-            a.append(ai)
+            c2i = init.c2_fromMAH(M[msk], t[msk], conctype)
+            Rvi = init.Rvir(M[msk][0], Delta=cfg.Dvsample[i], z=cfg.zsample[i])
             c2.append(c2i)
             Rv.append(Rvi)
-            if i == iz[0]:
-                Ms = Msi
             # print('    i=%6i,ci=%8.2f,ai=%8.2f,log(Msi)=%8.2f,c2i=%8.2f'%\
             #    (i,ci,ai,np.log10(Msi),c2i)) # <<< for test
-        if len(c) == 0:  # <<< safety, dealing with rare cases where the
-            # branch's root z[0] is close to the maximum redshift -- when
-            # this happens, the mass history has only one element, and
-            # z[0] can be slightly above cfg.zsample[i] for the very
-            # first iteration, leaving the lists c,a,c2,Rv never updated
-            ci, ai, Msi, c2i = init.Dekel_fromMAH(M, t, z[0], HaloResponse=HaloResponse)
-            c.append(ci)
-            a.append(ai)
-            c2.append(c2i)
-            Rv.append(Rvi)
-            Ms = Msi
-            # <<< test
-            # print('    branch root near max redshift: z=%7.2f,log(M)=%7.2f,c=%7.2f,a=%7.2f,c2=%7.2f,log(Ms)=%7.2f'%\
-            #    (z[0],np.log10(M[0]),c[0],a[0],c2[0],np.log10(Ms)))
-        c = np.array(c)
-        a = np.array(a)
         c2 = np.array(c2)
         Rv = np.array(Rv)
         Nc = len(c2)  # length of a branch over which c2 is computed
-
-        # compute stellar size at the root of the branch, i.e., at the
-        # accretion epoch (z[0])
-        Re = init.Reff(Rv[0], c2[0])
 
         # use the redshift id and parent-branch id to access the parent
         # branch's information at our current branch's accretion epoch,
@@ -203,14 +183,20 @@ def loop(itree):
             xv = np.zeros(6)
         else:
             Mp = mass[ip, iz[0]]
-            cp = DekelConcentration[ip, iz[0]]
-            ap = DekelSlope[ip, iz[0]]
-            hp = Dekel(Mp, cp, ap, Delta=200.0, z=zsample[0])
-            eps = 1.0 / np.pi * np.arccos(1.0 - 2.0 * np.random.random())
-            xv = init.orbit(hp, xc=1.0, eps=eps)
+            c2p = concentration[ip, iz[0]]
+            hp = NFW(Mp, c2p, Delta=cfg.Dvsample[iz[0]], z=zsample[0])
+            if optype == "zentner":
+                eps = 1.0 / np.pi * np.arccos(1.0 - 2.0 * np.random.random())
+                xv = init.orbit(hp, xc=1.0, eps=eps)
+            elif optype == "zzli":
+                vel_ratio, gamma = init.ZZLi2020(hp, Msample[0], zsample[0])
+                xv = init.orbit_from_Li2020(hp, vel_ratio, gamma)
+            elif optype == "jiang":
+                sp = NFW(Msample[0], c2[0], Delta=cfg.Dvsample[iz[0]], z=zsample[0])
+                xv = init.orbit_from_Jiang2015(hp, sp, zsample[0])
 
         # <<< test
-        # print('    id=%6i,k=%2i,z=%7.2f,log(M)=%7.2f,c=%7.2f,a=%7.2f,c2=%7.2f,log(Ms)=%7.2f,Re=%7.2f,xv=%7.2f,%7.2f,%7.2f,%7.2f,%7.2f,%7.2f'%\
+        # print('    id=%6i,k=%2i,z[0]=%7.2f,log(M[0])=%7.2f,c=%7.2f,a=%7.2f,c2=%7.2f,log(Ms)=%7.2f,Re=%7.2f,xv=%7.2f,%7.2f,%7.2f,%7.2f,%7.2f,%7.2f'%\
         #    (id,k,z[0],np.log10(M[0]),c[0],a[0],c2[0],np.log10(Ms),Re, xv[0],xv[1],xv[2],xv[3],xv[4],xv[5]))
 
         # update the arrays for output
@@ -220,11 +206,6 @@ def loop(itree):
 
         VirialRadius[id, iz[0] : iz[0] + Nc] = Rv
         concentration[id, iz[0] : iz[0] + Nc] = c2
-        DekelConcentration[id, iz[0] : iz[0] + Nc] = c
-        DekelSlope[id, iz[0] : iz[0] + Nc] = a
-
-        StellarMass[id, iz[0]] = Ms
-        StellarSize[id, iz[0]] = Re
 
         coordinates[id, iz[0], :] = xv
 
@@ -252,10 +233,6 @@ def loop(itree):
     ParentID = ParentID[: id + 1, :]
     VirialRadius = VirialRadius[: id + 1, :]
     concentration = concentration[: id + 1, :]
-    DekelConcentration = DekelConcentration[: id + 1, :]
-    DekelSlope = DekelSlope[: id + 1, :]
-    StellarMass = StellarMass[: id + 1, :]
-    StellarSize = StellarSize[: id + 1, :]
     coordinates = coordinates[: id + 1, :, :]
     np.savez(
         outfile1 % (itree, lgM0),
@@ -266,25 +243,20 @@ def loop(itree):
         ParentID=ParentID,
         VirialRadius=VirialRadius,
         concentration=concentration,
-        DekelConcentration=DekelConcentration,
-        DekelSlope=DekelSlope,
-        # VirialOverdensity = VirialOverdensity, # <<< no need in TreeGen
-        StellarMass=StellarMass,
-        StellarSize=StellarSize,
         coordinates=coordinates,
     )
 
     time_end_tmp = time.time()
     print(
-        "    Tree %5i: log(M_0)=%6.2f, %6i branches, %2i order, %8.1f sec"
-        % (itree, lgM0, Nbranch, k, time_end_tmp - time_start_tmp)
+        "    Tree %5i: %6i branches, %2i order, %8.1f sec"
+        % (itree, Nbranch, k, time_end_tmp - time_start_tmp)
     )
 
 
-# ---for parallelization, comment for testing in serial mode
 if __name__ == "__main__":
-    pool = Pool(cpu_count())  # use all cores
-    pool.map(loop, range(Ntree))
+    Ncores = int(sys.argv[1])
+    pool = Pool(Ncores)  # use as many as requested
+    pool.map(loop, range(Ntree), chunksize=1)
 
 time_end = time.time()
 print("    total time: %5.2f hours" % ((time_end - time_start) / 3600.0))


### PR DESCRIPTION
This PR migrates code that was intended to be run as a script into a new scripts subdirectory. The import statements at the top each modified file have been changed so that SatGen is imported as an externally installed library. Any other changes to these modules were just brought in by my editor enforcing PEP8, so I think their behavior should be identical as before. At some point it might be good to incorporate some unit tests that enforce this automatically, so then we could be sure, but maybe if you just spot-check me then I bet this is safe.

@JiangFangzhou